### PR TITLE
Add to most common errors descriptions and fixes

### DIFF
--- a/faqs.Rmd
+++ b/faqs.Rmd
@@ -109,6 +109,49 @@ rmd_files: ["index.Rmd",
 ```
 Commit the changes to your `_bookdown.yml` and see if the preview GitHub action runs appropriately.
 
+### `404 error`: GitHub Action link to download and preview `.docx` file is returning a 404 error
+
+If you get a 404 error after clicking the link while attempting to download the `.docx` file from the GitHub Action rendered previews, then add the following code to the end of the `_output.yml` file:
+
+```
+bookdown::word_document2:
+  toc: true
+```
+
+Commit the changes to your `_output.yml` and see if the preview GitHub action runs appropriately. 
+
+### `Error in if (title == x2) return(head) : the condition has length > 1`: Run bookdown render error
+
+If you observe an error like this:
+
+```
+Error in if (title == x2) return(head) : the condition has length > 1
+Calls: <Anonymous> ... split_chapters -> build -> sub -> is.factor -> prepend_chapter_title
+Execution halted
+Error: Process completed with exit code 1.
+```
+
+Then look at the `GA_Script.Rhtml` file and remove the following `html` frontmatter if it's present:
+
+(at the beginning of the file)
+
+```
+  <html>
+
+  <head>
+  <title>Title</title>
+  </head>
+
+  <body>
+```
+
+(at the end of the file)
+
+```
+  </body>
+  </html>
+```
+
 ## Ask a question on the Google Group
 
 You can always start a discussion on the [Discussions](https://github.com/jhudsl/OTTR_Template/discussions) tab above. You can also join our [Google Group](https://groups.google.com/g/jhudsl) to ask questions and keep in touch with the OTTR community.


### PR DESCRIPTION
This fix adds two common errors and their suggested fixes

The first is what to do when encountering a 404 error for the preview `.docx`. As discussed in slack and the [fix employed here](https://github.com/fhdsl/Ethical_Data_Handling_for_Cancer_Research/pull/66/commits/37c4ee05f3068e0bf7e655fd46fdca8361073dda#diff-3d7c1409fa062b9a744167bff65514791c7abf8ab5a0ca8ef34c8ae992c75262).

The second is that render preview error I've been getting off and on recently. I encountered it again yesterday with Choosing Genomics Tools after pushing a small change so I threw it in here since it's shown up a few times. I'll still go through repos and remove the frontmatter if I see it. But including it here since I'm not sure how the frontmatter is getting there. But referenced fixes employed [here](https://github.com/fhdsl/AI_for_Decision_Makers/commit/8f8ec320c2972bd840d69f595f9185b583acdf7d) and [here](https://github.com/fhdsl/AI_for_Efficient_Programming/commit/edb1b7e262fc2935cfbe0f76bb658e98aefd7b10) and [here](https://github.com/fhdsl/Choosing_Genomics_Tools/pull/58/commits/f34c1a3a82631c0d521e50c0e1a1cfaef5c16ccc)